### PR TITLE
fix: align Python tooling configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,8 @@ quote-style = "double"
 indent-style = "space"
 
 [tool.black]
-line-length = 88
-target-version = ['py38']
+line-length = 120
+target-version = ['py312']
 
 [tool.mypy]
 python_version = "3.12"

--- a/scripts/tanaka.py
+++ b/scripts/tanaka.py
@@ -92,9 +92,7 @@ def create_parser() -> argparse.ArgumentParser:
 def main() -> int:
     tasks = discover_tasks()
     parser = create_parser()
-    subparsers = parser.add_subparsers(
-        dest="command", help="Available commands", metavar="<command>"
-    )
+    subparsers = parser.add_subparsers(dest="command", help="Available commands", metavar="<command>")
 
     for task in tasks:
         task.add_subparser(subparsers)

--- a/scripts/tasks/generate.py
+++ b/scripts/tasks/generate.py
@@ -40,9 +40,7 @@ def generate_api_models() -> TaskResult:
 
     if not models_rs.exists():
         logger.error(f"Models file not found: {models_rs}")
-        return TaskResult(
-            success=False, message="Models file not found", exit_code=EXIT_FAILURE
-        )
+        return TaskResult(success=False, message="Models file not found", exit_code=EXIT_FAILURE)
 
     # Check if regeneration is needed
     needs_regeneration = True
@@ -67,9 +65,7 @@ def generate_api_models() -> TaskResult:
         models_time = datetime.fromtimestamp(models_rs.stat().st_mtime)
         sentinel_time = datetime.fromtimestamp(sentinel_file.stat().st_mtime)
         logger.warning("Generated model files are stale. Regenerating...")
-        logger.info(
-            f"Generated model file date: {sentinel_time.strftime('%Y-%m-%d %H:%M:%S')}"
-        )
+        logger.info(f"Generated model file date: {sentinel_time.strftime('%Y-%m-%d %H:%M:%S')}")
         logger.info(f"Model file date: {models_time.strftime('%Y-%m-%d %H:%M:%S')}")
     else:
         logger.warning("No generated model files found. Generating...")

--- a/scripts/tasks/lint.py
+++ b/scripts/tasks/lint.py
@@ -99,11 +99,7 @@ def run(args: argparse.Namespace) -> TaskResult:
     """Run linters based on arguments"""
     if args.markdown:
         exit_code = lint_markdown(fix=args.fix)
-        message = (
-            "Markdown linting completed"
-            if exit_code == 0
-            else "Markdown linting failed"
-        )
+        message = "Markdown linting completed" if exit_code == 0 else "Markdown linting failed"
         return TaskResult(
             success=exit_code == 0,
             message=message,
@@ -111,9 +107,7 @@ def run(args: argparse.Namespace) -> TaskResult:
         )
     elif args.python:
         exit_code = lint_python(fix=args.fix)
-        message = (
-            "Python linting completed" if exit_code == 0 else "Python linting failed"
-        )
+        message = "Python linting completed" if exit_code == 0 else "Python linting failed"
         return TaskResult(
             success=exit_code == 0,
             message=message,
@@ -152,10 +146,6 @@ Examples:
         """,
     )
     parser.add_argument("--fix", action="store_true", help="Fix issues automatically")
-    parser.add_argument(
-        "--markdown", "-m", action="store_true", help="Lint only markdown files"
-    )
-    parser.add_argument(
-        "--python", "-p", action="store_true", help="Lint only Python files"
-    )
+    parser.add_argument("--markdown", "-m", action="store_true", help="Lint only markdown files")
+    parser.add_argument("--python", "-p", action="store_true", help="Lint only Python files")
     parser.set_defaults(func=run)

--- a/scripts/tasks/setup_dev.py
+++ b/scripts/tasks/setup_dev.py
@@ -64,9 +64,7 @@ class DependencyInstaller:
         if self.dry_run:
             cmd_str = cmd if isinstance(cmd, str) else " ".join(cmd)
             logger.info(f"[DRY RUN] Would execute: {cmd_str}")
-            return subprocess.CompletedProcess(
-                args=cmd, returncode=0, stdout="", stderr=""
-            )
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
 
         # Special handling for shell commands
         if shell and isinstance(cmd, str):
@@ -111,9 +109,7 @@ class RustInstaller(DependencyInstaller):
         logger.info("Installing Rust...")
         try:
             rustup_url = "https://sh.rustup.rs"
-            install_cmd = (
-                f'curl --proto "=https" --tlsv1.2 -sSf {rustup_url} | sh -s -- -y'
-            )
+            install_cmd = f'curl --proto "=https" --tlsv1.2 -sSf {rustup_url} | sh -s -- -y'
             self.run_command(install_cmd, shell=True)
 
             cargo_env = os.path.expanduser("~/.cargo/env")
@@ -296,9 +292,7 @@ class FirefoxInstaller(DependencyInstaller):
                     logger.error(f"Failed to install Firefox: {e}")
                     return False
 
-        logger.warning(
-            "Please install Firefox 126+ from https://www.mozilla.org/firefox/"
-        )
+        logger.warning("Please install Firefox 126+ from https://www.mozilla.org/firefox/")
         return False
 
 
@@ -311,9 +305,7 @@ class SqliteChecker(DependencyInstaller):
             logger.success(f"SQLite is installed: {version}")
             return True
 
-        logger.warning(
-            "SQLite not found. Please install SQLite 3.40+ using your system package manager:"
-        )
+        logger.warning("SQLite not found. Please install SQLite 3.40+ using your system package manager:")
         if self.os_type == OSType.LINUX:
             logger.warning("  Ubuntu/Debian: sudo apt-get install sqlite3")
             logger.warning("  Fedora/RHEL: sudo dnf install sqlite")
@@ -338,9 +330,7 @@ class PythonInstaller(DependencyInstaller):
         try:
             result = self.run_command(["uv", "python", "list"])
             if result.stdout and f"cpython-{self.REQUIRED_VERSION}" in result.stdout:
-                logger.success(
-                    f"Python {self.REQUIRED_VERSION} already installed via uv"
-                )
+                logger.success(f"Python {self.REQUIRED_VERSION} already installed via uv")
                 return True
         except Exception:
             pass
@@ -364,9 +354,7 @@ class PythonInstaller(DependencyInstaller):
                     if match:
                         installed_version = match.group(1)
                         if float(installed_version) >= float(self.REQUIRED_VERSION):
-                            logger.info(
-                                f"System Python {installed_version} found and meets requirements"
-                            )
+                            logger.info(f"System Python {installed_version} found and meets requirements")
                             return True
 
             logger.warning("Could not install or find suitable Python version")
@@ -432,9 +420,7 @@ class SetupManager:
             "firefox": Dependency(name="firefox", check_cmd="firefox"),
             "sqlite": Dependency(name="sqlite", check_cmd="sqlite3"),
             "uv": Dependency(name="uv", check_cmd="uv"),
-            "python": Dependency(
-                name="python", depends_on=["uv"], check_cmd="uv python"
-            ),
+            "python": Dependency(name="python", depends_on=["uv"], check_cmd="uv python"),
             "venv": Dependency(name="venv", depends_on=["python", "uv"]),
         }
 
@@ -600,9 +586,7 @@ def run(args: argparse.Namespace) -> TaskResult:
         deps = parse_dependencies(args)
         manager = SetupManager(dry_run=args.dry_run)
         manager.setup(deps)
-        return TaskResult(
-            success=True, message="Setup completed successfully", exit_code=EXIT_SUCCESS
-        )
+        return TaskResult(success=True, message="Setup completed successfully", exit_code=EXIT_SUCCESS)
 
     except ValueError as e:
         message = str(e)

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -32,9 +32,7 @@ def run_command(
     """
     logger.info(f"Running: {' '.join(cmd)}")
     try:
-        return subprocess.run(
-            cmd, cwd=cwd, check=check, capture_output=False, text=True, env=env
-        )
+        return subprocess.run(cmd, cwd=cwd, check=check, capture_output=False, text=True, env=env)
     except FileNotFoundError:
         logger.error(f"Command not found: {cmd[0]}")
         raise


### PR DESCRIPTION
## Summary
- Aligned Python formatting tools to use consistent configuration
- Fixed mismatched line lengths between Black and Ruff
- Updated Black's target Python version to match project requirements

## Changes
- Set line length to 120 characters for both Black and Ruff (was 88 for Black, 120 for Ruff)
- Updated Black target version from Python 3.8 to Python 3.12 to match project's `requires-python = ">=3.12"`
- Applied Black formatting to all Python scripts with the new line length

## Why This Matters
- **Consistency**: Having different line lengths between formatters can cause conflicts and confusion
- **Correctness**: Black should target the same Python version as the project to ensure proper formatting
- **Readability**: 120 characters better utilizes modern screen widths while maintaining readability

## Test Plan
- [x] Verified Python linting passes with `python3 scripts/tanaka.py lint --python`
- [x] Confirmed both Black and Ruff agree on formatting
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)