### PR TITLE
feat: add webapp mode for testing without Firefox

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ Adopt the persona of a **pragmatic, experienced engineer** who values:
 - Centralize error management
 - Make invalid states unrepresentable through types
 - Prefer compile-time errors over runtime errors
+- NEVER use `any` type in TypeScript - the linter will reject it. Use proper types or `unknown` with type guards
 
 **Developer Experience**
 

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -244,6 +244,9 @@ pnpm run dev
 # Run Firefox with extension loaded
 pnpm run start
 
+# Run as webapp without Firefox
+pnpm run webapp
+
 # Bundle analysis
 pnpm run analyze
 
@@ -262,7 +265,52 @@ pnpm run watch
 
 ---
 
-## 9. Security Considerations
+## 9. Webapp Mode (Testing Without Firefox)
+
+The extension can run as a standalone webapp for testing and development without Firefox.
+
+### Starting Webapp Mode
+
+```bash
+# Run the extension as a webapp
+pnpm run webapp
+```
+
+This starts the development server at http://localhost:3000
+
+### Features
+
+- **Mock Browser API**: Simulates Firefox APIs with in-memory storage
+- **Route-based Navigation**: 
+  - `/` - Popup view
+  - `/settings` - Settings view
+- **Hot Module Replacement**: Changes update instantly
+- **Mock Data**: Pre-populated with sample tabs and windows
+
+### Architecture
+
+The webapp mode uses:
+- **Mock Browser** (`src/browser/mock.ts`): Implements all browser APIs with in-memory storage
+- **Webapp Container** (`src/di/webapp-container.ts`): Separate DI container that registers MockBrowser
+- **Webapp Entry** (`src/webapp/index.tsx`): React router setup for navigation
+
+### How It Works
+
+1. The `WEBAPP_MODE=true` environment variable triggers rspack aliasing
+2. `webextension-polyfill` imports are replaced with `mock-polyfill.ts`
+3. The DI container uses `MockBrowser` instead of the real browser API
+4. All browser operations (tabs, storage, messaging) work with mock data
+
+### Benefits
+
+- Test UI components without installing the extension
+- Faster development iteration
+- Easy debugging with browser DevTools
+- No Firefox required for UI development
+
+---
+
+## 10. Security Considerations
 
 - All communication uses TLS
 - Authentication via shared bearer token
@@ -271,9 +319,9 @@ pnpm run watch
 
 ---
 
-## 10. Debugging WebExtension Issues
+## 11. Debugging WebExtension Issues
 
-### 10.1 Extension Debugging Tools
+### 11.1 Extension Debugging Tools
 
 **Browser Console vs Extension Console:**
 
@@ -282,7 +330,7 @@ pnpm run watch
   - Shows background script errors and console logs
   - Allows setting breakpoints in background scripts
 
-### 10.2 Common Debugging Techniques
+### 11.2 Common Debugging Techniques
 
 **1. Enable Verbose Logging:**
 
@@ -328,7 +376,7 @@ browser.runtime.onMessage.addListener((message, sender) => {
 });
 ```
 
-### 10.3 Performance Profiling
+### 11.3 Performance Profiling
 
 ```javascript
 // Profile slow operations
@@ -340,7 +388,7 @@ console.timeEnd("sync-operation");
 console.log("Memory:", performance.memory);
 ```
 
-### 10.4 Testing CRDT State
+### 11.4 Testing CRDT State
 
 ```typescript
 // Inspect Yjs document state
@@ -351,9 +399,9 @@ console.log("Pending updates:", Y.encodeStateAsUpdate(doc));
 
 ---
 
-## 11. Security Best Practices
+## 12. Security Best Practices
 
-### 11.1 WebExtension Security
+### 12.1 WebExtension Security
 
 **Content Security Policy:**
 
@@ -405,7 +453,7 @@ await browser.storage.local.set({
 });
 ```
 
-### 11.2 API Communication Security
+### 12.2 API Communication Security
 
 **Always Use HTTPS:**
 
@@ -434,7 +482,7 @@ async function fetchWithTimeout(url: string, options: RequestInit = {}) {
 }
 ```
 
-### 11.3 Permission Management
+### 12.3 Permission Management
 
 **Request Minimal Permissions:**
 
@@ -462,9 +510,9 @@ if (!hasTabsPermission) {
 
 ---
 
-## 12. Troubleshooting Common Issues
+## 13. Troubleshooting Common Issues
 
-### 12.1 Extension Not Loading
+### 13.1 Extension Not Loading
 
 **Problem:** Extension doesn't appear in Firefox after installation
 
@@ -475,7 +523,7 @@ if (!hasTabsPermission) {
 3. Check browser console for manifest parsing errors
 4. Ensure all listed resources exist (icons, scripts)
 
-### 12.2 Server Connection Failures
+### 13.2 Server Connection Failures
 
 **Problem:** Extension can't connect to server
 
@@ -508,7 +556,7 @@ if (!hasTabsPermission) {
    # Check extension settings in about:addons
    ```
 
-### 12.3 Sync Not Working
+### 13.3 Sync Not Working
 
 **Problem:** Tabs not syncing between devices
 
@@ -525,7 +573,7 @@ if (!hasTabsPermission) {
 - Check SQLite database integrity: `sqlite3 tabs.db "PRAGMA integrity_check;"`
 - Ensure both devices have same server URL and token
 
-### 12.4 High Memory Usage
+### 13.4 High Memory Usage
 
 **Problem:** Extension consuming too much memory
 
@@ -559,7 +607,7 @@ if (!hasTabsPermission) {
    }
    ```
 
-### 12.5 Build Failures
+### 13.5 Build Failures
 
 **TypeScript Build Issues:**
 
@@ -588,7 +636,7 @@ cargo update
 cargo check --all-targets
 ```
 
-### 12.6 Performance Issues
+### 13.6 Performance Issues
 
 **Slow Extension Startup:**
 
@@ -602,7 +650,7 @@ cargo check --all-targets
 - Throttle/debounce frequent events
 - Profile with Firefox Performance tool
 
-### 12.7 Development Environment Issues
+### 13.7 Development Environment Issues
 
 **pnpm not found:**
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -19,6 +19,7 @@
     "analyze": "BUILD_ENV=production RSPACK_BUNDLE_ANALYZE=true rspack build",
     "start": "web-ext run --source-dir dist --firefox-profile=dev-profile --keep-profile-changes",
     "dev:extension": "concurrently \"pnpm watch\" \"pnpm start\"",
+    "webapp": "WEBAPP_MODE=true rspack serve --mode development --config rspack.config.ts",
     "lint": "eslint 'src/**/*.ts' 'scripts/**/*.ts'",
     "lint:fix": "eslint 'src/**/*.ts' 'scripts/**/*.ts' --fix",
     "format": "prettier --write 'src/**/*.{ts,html,css}' 'scripts/**/*.ts' 'manifest.json'",
@@ -79,6 +80,7 @@
   "dependencies": {
     "@preact/signals": "^2.2.0",
     "preact": "^10.26.9",
+    "preact-router": "^4.1.2",
     "reflect-metadata": "^0.2.2",
     "tsyringe": "^4.10.0",
     "yjs": "^13.6.27"

--- a/extension/pnpm-lock.yaml
+++ b/extension/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       preact:
         specifier: ^10.26.9
         version: 10.26.9
+      preact-router:
+        specifier: ^4.1.2
+        version: 4.1.2(preact@10.26.9)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -3384,6 +3387,11 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  preact-router@4.1.2:
+    resolution: {integrity: sha512-uICUaUFYh+XQ+6vZtQn1q+X6rSqwq+zorWOCLWPF5FAsQh3EJ+RsDQ9Ee+fjk545YWQHfUxhrBAaemfxEnMOUg==}
+    peerDependencies:
+      preact: '>=10'
 
   preact@10.26.9:
     resolution: {integrity: sha512-SSjF9vcnF27mJK1XyFMNJzFd5u3pQiATFqoaDy03XuN00u4ziveVVEGt5RKJrDR8MHE/wJo9Nnad56RLzS2RMA==}
@@ -8077,6 +8085,10 @@ snapshots:
       find-up: 4.1.0
 
   possible-typed-array-names@1.1.0: {}
+
+  preact-router@4.1.2(preact@10.26.9):
+    dependencies:
+      preact: 10.26.9
 
   preact@10.26.9: {}
 

--- a/extension/rspack.config.ts
+++ b/extension/rspack.config.ts
@@ -10,6 +10,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const isDev = process.env.NODE_ENV === 'development';
 const buildEnv = process.env.BUILD_ENV || 'development';
 const isAnalyze = process.env.RSPACK_BUNDLE_ANALYZE === 'true';
+const isWebapp = process.env.WEBAPP_MODE === 'true';
 
 export default defineConfig({
   context: __dirname,
@@ -19,6 +20,7 @@ export default defineConfig({
     background: './src/background.ts',
     'popup/popup': './src/popup/popup.tsx',
     'settings/settings': './src/settings/settings.tsx',
+    webapp: './src/webapp/index.tsx',
   },
 
   output: {
@@ -38,6 +40,9 @@ export default defineConfig({
       '@env': resolve(__dirname, `src/config/environments/${buildEnv}.ts`),
       'react': 'preact/compat',
       'react-dom': 'preact/compat',
+      ...(isWebapp ? {
+        'webextension-polyfill': resolve(__dirname, 'src/browser/mock-polyfill.ts'),
+      } : {}),
     },
   },
 
@@ -104,6 +109,13 @@ export default defineConfig({
       filename: 'settings/settings.html',
       chunks: ['settings/settings'],
       inject: false,
+    }),
+
+    new HtmlRspackPlugin({
+      template: './src/webapp/index.html',
+      filename: 'index.html',
+      chunks: ['webapp'],
+      inject: true,
     }),
 
     new rspack.CopyRspackPlugin({
@@ -175,6 +187,10 @@ export default defineConfig({
     devMiddleware: {
       writeToDisk: true,
     },
+    historyApiFallback: {
+      index: '/index.html',
+    },
+    open: true,
   },
 
   devtool: isDev ? 'source-map' : false,

--- a/extension/src/browser/mock-polyfill.ts
+++ b/extension/src/browser/mock-polyfill.ts
@@ -1,0 +1,9 @@
+// Mock webextension-polyfill for webapp mode
+const mockBrowser = {
+  tabs: {},
+  windows: {},
+  storage: { local: {} },
+  runtime: {},
+};
+
+export default mockBrowser;

--- a/extension/src/browser/mock.ts
+++ b/extension/src/browser/mock.ts
@@ -1,0 +1,337 @@
+import type { IBrowser, ITabs, IWindows, ILocalStorage, IRuntime, IEventEmitter } from './core';
+import type { Tabs, Windows, Runtime } from 'webextension-polyfill';
+
+// Mock event emitter that matches the interface
+class MockEventEmitter<T extends unknown[]> implements IEventEmitter<T> {
+  private listeners: ((...args: T) => void)[] = [];
+
+  addListener(callback: (...args: T) => void): void {
+    this.listeners.push(callback);
+  }
+
+  removeListener(callback: (...args: T) => void): void {
+    const index = this.listeners.indexOf(callback);
+    if (index > -1) {
+      this.listeners.splice(index, 1);
+    }
+  }
+
+  trigger(...args: T): void {
+    for (const listener of this.listeners) {
+      listener(...args);
+    }
+  }
+}
+
+/**
+ * Mock browser implementation for webapp testing
+ * Simulates Firefox API behavior with in-memory storage
+ */
+export class MockBrowser implements IBrowser {
+  private mockTabs = new Map<number, Tabs.Tab>();
+  private mockWindows = new Map<number, Windows.Window>();
+  private mockStorage = new Map<string, unknown>();
+  private tabIdCounter = 1;
+  private windowIdCounter = 1;
+
+  // Event emitters
+  private tabCreatedEmitter = new MockEventEmitter<[tab: Tabs.Tab]>();
+  private tabUpdatedEmitter = new MockEventEmitter<
+    [tabId: number, changeInfo: Tabs.OnUpdatedChangeInfoType, tab: Tabs.Tab]
+  >();
+  private tabRemovedEmitter = new MockEventEmitter<
+    [tabId: number, removeInfo: Tabs.OnRemovedRemoveInfoType]
+  >();
+  private tabMovedEmitter = new MockEventEmitter<
+    [tabId: number, moveInfo: Tabs.OnMovedMoveInfoType]
+  >();
+  private windowRemovedEmitter = new MockEventEmitter<[windowId: number]>();
+  private messageEmitter = new MockEventEmitter<
+    [message: unknown, sender: Runtime.MessageSender, sendResponse: (response?: unknown) => void]
+  >();
+
+  constructor() {
+    // Initialize with some mock data
+    this.initializeMockData();
+  }
+
+  private initializeMockData(): void {
+    // Create a mock window
+    const windowId = this.windowIdCounter++;
+    this.mockWindows.set(windowId, {
+      id: windowId,
+      focused: true,
+      incognito: false,
+      alwaysOnTop: false,
+      tabs: [],
+    } as Windows.Window);
+
+    // Add some mock tabs
+    this.addMockTab(windowId, 'https://github.com', 'GitHub');
+    this.addMockTab(windowId, 'https://news.ycombinator.com', 'Hacker News');
+    this.addMockTab(windowId, 'https://developer.mozilla.org', 'MDN Web Docs');
+  }
+
+  private addMockTab(windowId: number, url: string, title: string): number {
+    const tabId = this.tabIdCounter++;
+    const tab: Tabs.Tab = {
+      id: tabId,
+      windowId,
+      url,
+      title,
+      active: this.mockTabs.size === 0,
+      pinned: false,
+      index: this.mockTabs.size,
+      highlighted: false,
+      incognito: false,
+    } as Tabs.Tab;
+
+    this.mockTabs.set(tabId, tab);
+
+    const window = this.mockWindows.get(windowId);
+    if (window) {
+      window.tabs = window.tabs || [];
+      window.tabs.push(tab);
+    }
+
+    return tabId;
+  }
+
+  // Tabs API
+  tabs: ITabs = {
+    query: async (queryInfo: Tabs.QueryQueryInfoType): Promise<Tabs.Tab[]> => {
+      let tabs = Array.from(this.mockTabs.values());
+
+      if (queryInfo.windowId !== undefined) {
+        tabs = tabs.filter((t) => t.windowId === queryInfo.windowId);
+      }
+      if (queryInfo.active !== undefined) {
+        tabs = tabs.filter((t) => t.active === queryInfo.active);
+      }
+      if (queryInfo.pinned !== undefined) {
+        tabs = tabs.filter((t) => t.pinned === queryInfo.pinned);
+      }
+      if (queryInfo.currentWindow !== undefined && queryInfo.currentWindow) {
+        // For mock, just return tabs from the first window
+        const firstWindowId = Array.from(this.mockWindows.keys())[0];
+        tabs = tabs.filter((t) => t.windowId === firstWindowId);
+      }
+
+      return tabs.map((t) => ({ ...t }));
+    },
+
+    create: async (createProperties: Tabs.CreateCreatePropertiesType): Promise<Tabs.Tab> => {
+      const windowId = createProperties.windowId || Array.from(this.mockWindows.keys())[0];
+      const tabId = this.addMockTab(windowId, createProperties.url || 'about:blank', 'New Tab');
+      const tab = this.mockTabs.get(tabId);
+      if (!tab) throw new Error(`Tab ${tabId} not found`);
+
+      if (createProperties.active !== undefined) {
+        tab.active = createProperties.active;
+      }
+      if (createProperties.pinned !== undefined) {
+        tab.pinned = createProperties.pinned;
+      }
+      if (createProperties.index !== undefined) {
+        tab.index = createProperties.index;
+      }
+
+      // Simulate tab created event
+      setTimeout(() => {
+        this.tabCreatedEmitter.trigger(tab);
+      }, 10);
+
+      return { ...tab };
+    },
+
+    remove: async (tabId: number): Promise<void> => {
+      const tab = this.mockTabs.get(tabId);
+      if (tab) {
+        this.mockTabs.delete(tabId);
+
+        // Remove from window
+        const windowId = tab.windowId;
+        if (windowId !== undefined) {
+          const window = this.mockWindows.get(windowId);
+          if (window && window.tabs) {
+            window.tabs = window.tabs.filter((t) => t.id !== tabId);
+          }
+        }
+
+        // Simulate tab removed event
+        setTimeout(() => {
+          this.tabRemovedEmitter.trigger(tabId, {
+            windowId: windowId || 0,
+            isWindowClosing: false,
+          });
+        }, 10);
+      }
+    },
+
+    update: async (
+      tabId: number,
+      updateProperties: Tabs.UpdateUpdatePropertiesType,
+    ): Promise<Tabs.Tab> => {
+      const tab = this.mockTabs.get(tabId);
+      if (!tab) throw new Error(`Tab ${tabId} not found`);
+
+      const changeInfo: Tabs.OnUpdatedChangeInfoType = {};
+
+      if (updateProperties.url !== undefined) {
+        changeInfo.url = updateProperties.url;
+        tab.url = updateProperties.url;
+      }
+      if (updateProperties.active !== undefined) {
+        tab.active = updateProperties.active;
+      }
+      if (updateProperties.pinned !== undefined) {
+        changeInfo.pinned = updateProperties.pinned;
+        tab.pinned = updateProperties.pinned;
+      }
+
+      // Simulate tab updated event
+      setTimeout(() => {
+        this.tabUpdatedEmitter.trigger(tabId, changeInfo, tab);
+      }, 10);
+
+      return { ...tab };
+    },
+
+    move: async (tabId: number, moveProperties: Tabs.MoveMovePropertiesType): Promise<Tabs.Tab> => {
+      const tab = this.mockTabs.get(tabId);
+      if (!tab) throw new Error(`Tab ${tabId} not found`);
+
+      const fromIndex = tab.index;
+      const toIndex = moveProperties.index;
+      const toWindowId = moveProperties.windowId || tab.windowId;
+
+      // Update tab properties
+      tab.index = toIndex;
+      if (moveProperties.windowId !== undefined) {
+        tab.windowId = moveProperties.windowId;
+      }
+
+      // Simulate tab moved event
+      setTimeout(() => {
+        this.tabMovedEmitter.trigger(tabId, {
+          windowId: toWindowId || tab.windowId || 0,
+          fromIndex,
+          toIndex,
+        });
+      }, 10);
+
+      return { ...tab };
+    },
+
+    onCreated: this.tabCreatedEmitter,
+    onRemoved: this.tabRemovedEmitter,
+    onUpdated: this.tabUpdatedEmitter,
+    onMoved: this.tabMovedEmitter,
+  };
+
+  // Windows API
+  windows: IWindows = {
+    getCurrent: async (): Promise<Windows.Window> => {
+      const window = Array.from(this.mockWindows.values())[0];
+      if (!window) throw new Error('No windows available');
+      return { ...window };
+    },
+
+    getAll: async (): Promise<Windows.Window[]> => {
+      return Array.from(this.mockWindows.values()).map((w) => ({ ...w }));
+    },
+
+    onRemoved: this.windowRemovedEmitter,
+  };
+
+  // Storage API
+  localStorage: ILocalStorage = {
+    get: async (keys?: string | string[] | null): Promise<Record<string, unknown>> => {
+      if (!keys) {
+        return Object.fromEntries(this.mockStorage);
+      }
+
+      const keyArray = Array.isArray(keys) ? keys : [keys];
+      const result: Record<string, unknown> = {};
+
+      for (const key of keyArray) {
+        if (this.mockStorage.has(key)) {
+          result[key] = this.mockStorage.get(key);
+        }
+      }
+
+      return result;
+    },
+
+    set: async (items: Record<string, unknown>): Promise<void> => {
+      for (const [key, value] of Object.entries(items)) {
+        this.mockStorage.set(key, value);
+      }
+      console.log('[Mock] Storage set:', items);
+    },
+
+    remove: async (keys: string | string[]): Promise<void> => {
+      const keyArray = Array.isArray(keys) ? keys : [keys];
+      for (const key of keyArray) {
+        this.mockStorage.delete(key);
+      }
+      console.log('[Mock] Storage removed:', keys);
+    },
+
+    clear: async (): Promise<void> => {
+      this.mockStorage.clear();
+      console.log('[Mock] Storage cleared');
+    },
+  };
+
+  // Runtime API
+  runtime: IRuntime = {
+    getManifest: () => {
+      return {
+        version: '0.5.0',
+        name: 'Tanaka',
+        description: 'Firefox extension for cross-device tab synchronization',
+      };
+    },
+
+    openOptionsPage: async (): Promise<void> => {
+      console.log('[Mock] Opening options page');
+      window.open('/settings', '_blank');
+    },
+
+    sendMessage: async (message: unknown): Promise<unknown> => {
+      console.log('[Mock] Message sent:', message);
+
+      // Simulate async message handling
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          let responseReceived = false;
+          const sendResponse = (response?: unknown) => {
+            if (!responseReceived) {
+              responseReceived = true;
+              resolve(response);
+            }
+          };
+
+          this.messageEmitter.trigger(
+            message,
+            {
+              tab: undefined,
+              id: 'mock-extension',
+            } as Runtime.MessageSender,
+            sendResponse,
+          );
+
+          // If no response after a timeout, resolve with undefined
+          setTimeout(() => {
+            if (!responseReceived) {
+              resolve(undefined);
+            }
+          }, 100);
+        }, 10);
+      });
+    },
+
+    onMessage: this.messageEmitter,
+  };
+}

--- a/extension/src/di/webapp-container.ts
+++ b/extension/src/di/webapp-container.ts
@@ -1,0 +1,45 @@
+import 'reflect-metadata';
+import { container } from 'tsyringe';
+import { UserSettingsManager } from '../sync/user-settings';
+import { TanakaAPI } from '../api/api';
+import { WindowTracker } from '../sync/window-tracker';
+import { SyncManager } from '../sync/sync-manager';
+import { TabEventHandler } from '../sync/tab-event-handler';
+import { MessageHandler } from '../sync/message-handler';
+import { getConfig } from '../config';
+import { MockBrowser } from '../browser/mock';
+import type { IBrowser } from '../browser/core';
+
+// Create webapp container
+const webappContainer = container.createChildContainer();
+
+// Register mock browser
+webappContainer.register<IBrowser>('IBrowser', {
+  useClass: MockBrowser,
+});
+
+// Register singleton instances
+webappContainer.registerSingleton<UserSettingsManager>(UserSettingsManager);
+webappContainer.registerSingleton<WindowTracker>(WindowTracker);
+
+// Register TanakaAPI with factory
+webappContainer.register<TanakaAPI>(TanakaAPI, {
+  useFactory: () => new TanakaAPI(getConfig().serverUrl),
+});
+
+// Register SyncManager as singleton
+webappContainer.registerSingleton<SyncManager>(SyncManager);
+
+// Register TabEventHandler as singleton
+webappContainer.registerSingleton<TabEventHandler>(TabEventHandler);
+
+// Register MessageHandler with factory
+webappContainer.register<MessageHandler>(MessageHandler, {
+  useFactory: (dependencyContainer) => {
+    const windowTracker = dependencyContainer.resolve(WindowTracker);
+    const syncManager = dependencyContainer.resolve(SyncManager);
+    return new MessageHandler(windowTracker, syncManager);
+  },
+});
+
+export { webappContainer };

--- a/extension/src/webapp/index.html
+++ b/extension/src/webapp/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tanaka Webapp</title>
+    <style>
+      body {
+        margin: 0;
+        font-family:
+          -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
+          sans-serif;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/extension/src/webapp/index.tsx
+++ b/extension/src/webapp/index.tsx
@@ -1,0 +1,74 @@
+import 'reflect-metadata';
+import { render } from 'preact';
+import { Router, Route } from 'preact-router';
+import { webappContainer } from '../di/webapp-container';
+import { PopupApp } from '../popup/components/PopupApp';
+import { SettingsApp } from '../settings/components/SettingsApp';
+import { DIProvider } from '../di/provider';
+import '../popup/popup.css';
+import '../settings/settings.css';
+
+// Load Preact DevTools
+if (process.env.NODE_ENV === 'development') {
+  import('preact/debug');
+}
+
+function WebApp() {
+  return (
+    <DIProvider container={webappContainer}>
+      <div style={{ minHeight: '100vh', backgroundColor: '#f3f4f6' }}>
+        <nav style={{ 
+          backgroundColor: 'white', 
+          boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
+          padding: '1rem'
+        }}>
+          <div style={{ maxWidth: '1200px', margin: '0 auto', display: 'flex', gap: '2rem' }}>
+            <h1 style={{ margin: 0, fontSize: '1.5rem' }}>Tanaka Webapp</h1>
+            <a href="/" style={{ alignSelf: 'center' }}>Popup</a>
+            <a href="/settings" style={{ alignSelf: 'center' }}>Settings</a>
+          </div>
+        </nav>
+        
+        <main style={{ maxWidth: '1200px', margin: '2rem auto', padding: '0 1rem' }}>
+          <Router>
+            <Route path="/" component={PopupView} />
+            <Route path="/settings" component={SettingsView} />
+          </Router>
+        </main>
+      </div>
+    </DIProvider>
+  );
+}
+
+function PopupView() {
+  return (
+    <div style={{ 
+      backgroundColor: 'white', 
+      borderRadius: '8px', 
+      boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
+      width: '400px',
+      margin: '0 auto'
+    }}>
+      <PopupApp />
+    </div>
+  );
+}
+
+function SettingsView() {
+  return (
+    <div style={{ 
+      backgroundColor: 'white', 
+      borderRadius: '8px', 
+      boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
+      padding: '2rem'
+    }}>
+      <SettingsApp />
+    </div>
+  );
+}
+
+// Render the webapp
+const root = document.getElementById('root');
+if (root) {
+  render(<WebApp />, root);
+}


### PR DESCRIPTION
- Create mock browser implementation with full API surface
- Add webapp entry point with routing for popup/settings views
- Configure rspack aliasing to swap webextension-polyfill in webapp mode
- Create separate DI container that uses MockBrowser
- Add pnpm run webapp command to start dev server at localhost:3000
- Document webapp mode in DEV.md section 9
- Update CLAUDE.md to forbid 'any' type usage

This allows testing the extension UI without installing in Firefox, enabling faster development iteration and easier debugging.

🤖 Generated with [Claude Code](https://claude.ai/code)