### PR TITLE
feat(server): add comprehensive integration tests for sync endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,12 +91,7 @@ jobs:
       - name: Run server tests
         run: |
           cd server
-          cargo test --lib --verbose
-
-      - name: Run doc tests
-        run: |
-          cd server
-          cargo test --doc --verbose
+          cargo test --verbose
 
   test-extension:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,7 +96,7 @@ repos:
 
       - id: rust-tests
         name: Run Rust tests
-        entry: bash -c 'cd server && cargo test --lib'
+        entry: bash -c 'cd server && cargo test'
         language: system
         files: ^server/.*\.rs$
         pass_filenames: false

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -135,6 +135,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -670,6 +676,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "h2"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,6 +814,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -797,6 +823,7 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
 ]
 
 [[package]]
@@ -1870,6 +1897,8 @@ dependencies = [
  "clap",
  "dashmap",
  "dotenvy",
+ "http-body-util",
+ "hyper",
  "serde",
  "serde_json",
  "sqlx",
@@ -2018,6 +2047,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
 dependencies = [
  "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
  "pin-project-lite",
  "tokio",
 ]
@@ -2183,6 +2225,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "ts-rs"
 version = "10.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2289,6 +2337,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -48,3 +48,6 @@ generate-api-models = []
 
 [dev-dependencies]
 tempfile = "3"
+tower = { version = "0.5", features = ["util"] }
+hyper = { version = "1.5", features = ["full"] }
+http-body-util = "0.1"

--- a/server/src/crdt.rs
+++ b/server/src/crdt.rs
@@ -378,6 +378,11 @@ impl CrdtManager {
     }
 
     #[must_use]
+    pub fn tick_clock(&self) -> u64 {
+        self.clock.tick()
+    }
+
+    #[must_use]
     pub fn node_id(&self) -> u32 {
         self.clock.node_id()
     }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -3,3 +3,183 @@ pub mod crdt;
 pub mod error;
 pub mod models;
 pub mod sync;
+
+use crate::crdt::CrdtManager;
+use axum::{
+    middleware,
+    response::IntoResponse,
+    routing::{get, post},
+    Json, Router,
+};
+use serde::Serialize;
+use sqlx::SqlitePool;
+use std::sync::Arc;
+use tower_http::cors::CorsLayer;
+
+#[derive(Serialize)]
+struct HealthResponse {
+    status: String,
+    version: String,
+}
+
+/// Create the app router for testing
+pub fn create_app(
+    db_pool: SqlitePool,
+    crdt_manager: Arc<CrdtManager>,
+    auth_config: config::AuthConfig,
+) -> Router {
+    let auth_middleware_layer = middleware::from_fn_with_state(auth_config, auth_middleware);
+
+    let mut app = Router::new().route("/health", get(health)).route(
+        "/sync",
+        post(sync::sync_handler)
+            .with_state((crdt_manager, db_pool))
+            .route_layer(auth_middleware_layer),
+    );
+
+    app = app.layer(CorsLayer::permissive());
+    app
+}
+
+async fn health() -> Json<HealthResponse> {
+    Json(HealthResponse {
+        status: "ok".to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+    })
+}
+
+/// Auth middleware for testing
+///
+/// # Errors
+///
+/// Returns an error response if authentication fails
+pub async fn auth_middleware(
+    axum::extract::State(auth_config): axum::extract::State<config::AuthConfig>,
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> Result<axum::response::Response, axum::response::Response> {
+    const BEARER_PREFIX: &str = "Bearer ";
+
+    let auth_header = req
+        .headers()
+        .get(&auth_config.token_header)
+        .and_then(|value| value.to_str().ok());
+
+    match auth_header {
+        Some(auth) if auth.starts_with(BEARER_PREFIX) => {
+            let token = &auth[BEARER_PREFIX.len()..];
+            if token == auth_config.shared_token {
+                Ok(next.run(req).await)
+            } else {
+                Err(
+                    error::AppError::auth_token_invalid("Invalid authentication token")
+                        .into_response(),
+                )
+            }
+        }
+        Some(_) => Err(error::AppError::auth_token_invalid(
+            "Invalid authorization format. Use: Bearer <token>",
+        )
+        .into_response()),
+        None => Err(error::AppError::auth_token_missing().into_response()),
+    }
+}
+
+/// Setup database for testing
+///
+/// # Errors
+///
+/// Returns `AppError` if database setup fails
+pub async fn setup_database(
+    config: &config::DatabaseConfig,
+) -> Result<SqlitePool, error::AppError> {
+    use sqlx::sqlite::SqlitePoolOptions;
+    use std::time::Duration;
+
+    const CREATE_TABS_TABLE_SQL: &str = r"
+        CREATE TABLE IF NOT EXISTS tabs (
+            id TEXT PRIMARY KEY,
+            window_id TEXT NOT NULL,
+            data TEXT NOT NULL,
+            updated_at INTEGER NOT NULL
+        )
+    ";
+
+    const CREATE_CRDT_OPERATIONS_TABLE_SQL: &str = r"
+        CREATE TABLE IF NOT EXISTS crdt_operations (
+            id TEXT PRIMARY KEY,
+            clock INTEGER NOT NULL,
+            device_id TEXT NOT NULL,
+            operation_type TEXT NOT NULL,
+            target_id TEXT NOT NULL,
+            operation_data TEXT NOT NULL,
+            created_at INTEGER NOT NULL
+        )
+    ";
+
+    const CREATE_CRDT_STATE_TABLE_SQL: &str = r"
+        CREATE TABLE IF NOT EXISTS crdt_state (
+            entity_type TEXT NOT NULL,
+            entity_id TEXT NOT NULL,
+            current_data TEXT NOT NULL,
+            last_clock INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            PRIMARY KEY (entity_type, entity_id)
+        )
+    ";
+
+    let pool = SqlitePoolOptions::new()
+        .max_connections(config.max_connections)
+        .acquire_timeout(Duration::from_secs(config.connection_timeout_secs))
+        .connect(&config.url)
+        .await
+        .map_err(|e| error::AppError::database(format!("Failed to connect to database: {e}"), e))?;
+
+    // Configure SQLite for better performance
+    sqlx::query("PRAGMA journal_mode = WAL")
+        .execute(&pool)
+        .await
+        .map_err(|e| error::AppError::database("Failed to set journal mode", e))?;
+
+    let busy_timeout_ms = config.connection_timeout_secs * 1000;
+    sqlx::query(&format!("PRAGMA busy_timeout = {busy_timeout_ms}"))
+        .execute(&pool)
+        .await
+        .map_err(|e| error::AppError::database("Failed to set busy timeout", e))?;
+
+    sqlx::query("PRAGMA synchronous = NORMAL")
+        .execute(&pool)
+        .await
+        .map_err(|e| error::AppError::database("Failed to set synchronous mode", e))?;
+
+    // Create tables
+    sqlx::query(CREATE_TABS_TABLE_SQL)
+        .execute(&pool)
+        .await
+        .map_err(|e| error::AppError::database("Failed to create tabs table", e))?;
+
+    sqlx::query(CREATE_CRDT_OPERATIONS_TABLE_SQL)
+        .execute(&pool)
+        .await
+        .map_err(|e| error::AppError::database("Failed to create CRDT operations table", e))?;
+
+    sqlx::query(CREATE_CRDT_STATE_TABLE_SQL)
+        .execute(&pool)
+        .await
+        .map_err(|e| error::AppError::database("Failed to create CRDT state table", e))?;
+
+    // Create indexes
+    sqlx::query("CREATE INDEX IF NOT EXISTS idx_crdt_operations_clock ON crdt_operations(clock)")
+        .execute(&pool)
+        .await
+        .map_err(|e| error::AppError::database("Failed to create clock index", e))?;
+
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS idx_crdt_operations_target ON crdt_operations(target_id)",
+    )
+    .execute(&pool)
+    .await
+    .map_err(|e| error::AppError::database("Failed to create target index", e))?;
+
+    Ok(pool)
+}

--- a/server/src/sync.rs
+++ b/server/src/sync.rs
@@ -245,7 +245,7 @@ pub async fn sync_handler(
     // Process incoming operations
     let mut processed_operations = Vec::new();
     for operation in request.operations {
-        let operation_clock = crdt_manager.current_clock();
+        let operation_clock = crdt_manager.tick_clock();
 
         tracing::debug!(
             operation_type = operation.operation_type(),

--- a/server/tests/README.md
+++ b/server/tests/README.md
@@ -1,0 +1,44 @@
+# Tanaka Server Integration Tests
+
+This directory contains integration tests for the Tanaka server's sync endpoint.
+
+## Test Coverage
+
+The `sync_integration.rs` file contains comprehensive tests for the CRDT sync protocol:
+
+1. **Basic Operations**
+   - `test_sync_with_empty_operations` - Verifies empty sync requests work correctly
+   - `test_sync_with_upsert_tab_operation` - Tests single tab creation
+
+2. **Authentication**
+   - `test_sync_unauthorized` - Ensures invalid tokens are rejected
+
+3. **Multi-Device Sync**
+   - `test_sync_between_devices` - Verifies operations sync between different devices
+   - `test_incremental_sync` - Tests the `since_clock` parameter for efficient syncing
+
+4. **Complex Operations**
+   - `test_sync_with_multiple_operation_types` - Tests various CRDT operation types in one request
+
+5. **Error Handling**
+   - `test_sync_with_invalid_operation` - Validates operation validation works correctly
+
+## Running Tests
+
+```bash
+# Run all integration tests
+cargo test --test sync_integration
+
+# Run a specific test
+cargo test test_sync_between_devices
+
+# Run with output
+cargo test --test sync_integration -- --nocapture
+```
+
+## Key Implementation Details
+
+- Tests use an in-memory SQLite database for isolation
+- Each test creates its own app instance with auth middleware
+- The server properly increments Lamport clocks for each operation
+- Device-specific filtering prevents operation echo

--- a/server/tests/sync_integration.rs
+++ b/server/tests/sync_integration.rs
@@ -1,0 +1,373 @@
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+    Router,
+};
+use http_body_util::BodyExt;
+use sqlx::SqlitePool;
+use std::sync::Arc;
+use tanaka_server::{
+    config::{AuthConfig, DatabaseConfig},
+    crdt::CrdtManager,
+    setup_database,
+    sync::{CrdtOperation, SyncRequest, SyncResponse, TabData},
+};
+use tower::ServiceExt;
+
+/// Create a test database in memory
+async fn create_test_db() -> SqlitePool {
+    let config = DatabaseConfig {
+        url: "sqlite::memory:".to_string(),
+        max_connections: 5,
+        connection_timeout_secs: 30,
+    };
+
+    setup_database(&config)
+        .await
+        .expect("Failed to setup test database")
+}
+
+/// Create a test app with auth middleware
+fn create_test_app(db_pool: SqlitePool) -> Router {
+    let crdt_manager = Arc::new(CrdtManager::new(1)); // Node ID 1 for tests
+    let auth_config = AuthConfig {
+        shared_token: "test-token".to_string(),
+        token_header: "authorization".to_string(),
+        rate_limiting: false,
+        max_requests_per_minute: 60,
+    };
+
+    tanaka_server::create_app(db_pool, crdt_manager, auth_config)
+}
+
+/// Helper to make authenticated requests
+async fn make_sync_request(
+    app: Router,
+    token: &str,
+    request_body: SyncRequest,
+) -> (StatusCode, String) {
+    let request = Request::builder()
+        .method("POST")
+        .uri("/sync")
+        .header("Authorization", format!("Bearer {token}"))
+        .header("Content-Type", "application/json")
+        .body(Body::from(serde_json::to_string(&request_body).unwrap()))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    let status = response.status();
+    let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let body_string = String::from_utf8(body_bytes.to_vec()).unwrap();
+
+    (status, body_string)
+}
+
+#[tokio::test]
+async fn test_sync_with_empty_operations() {
+    // Setup
+    let db_pool = create_test_db().await;
+    let app = create_test_app(db_pool);
+
+    // Create request with no operations
+    let request = SyncRequest {
+        clock: 0,
+        device_id: "test-device-1".to_string(),
+        since_clock: None,
+        operations: vec![],
+    };
+
+    // Make request
+    let (status, body) = make_sync_request(app, "test-token", request).await;
+
+    // Verify response
+    assert_eq!(status, StatusCode::OK);
+    let response: SyncResponse = serde_json::from_str(&body).unwrap();
+    assert_eq!(response.operations.len(), 0);
+}
+
+#[tokio::test]
+async fn test_sync_unauthorized() {
+    // Setup
+    let db_pool = create_test_db().await;
+    let app = create_test_app(db_pool);
+
+    // Create request
+    let request = SyncRequest {
+        clock: 0,
+        device_id: "test-device-1".to_string(),
+        since_clock: None,
+        operations: vec![],
+    };
+
+    // Make request with wrong token
+    let (status, _body) = make_sync_request(app, "wrong-token", request).await;
+
+    // Verify response
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_sync_with_upsert_tab_operation() {
+    // Setup
+    let db_pool = create_test_db().await;
+    let app = create_test_app(db_pool);
+
+    // Create request with upsert tab operation
+    let operation = CrdtOperation::UpsertTab {
+        id: "tab-1".to_string(),
+        data: TabData {
+            window_id: "window-1".to_string(),
+            url: "https://example.com".to_string(),
+            title: "Example".to_string(),
+            active: true,
+            index: 0,
+            updated_at: 123_456_789,
+        },
+    };
+
+    let request = SyncRequest {
+        clock: 1,
+        device_id: "test-device-1".to_string(),
+        since_clock: None,
+        operations: vec![operation],
+    };
+
+    // Make request
+    let (status, body) = make_sync_request(app, "test-token", request).await;
+
+    // Verify response
+    assert_eq!(status, StatusCode::OK);
+    let response: SyncResponse = serde_json::from_str(&body).unwrap();
+
+    // Server should update clock
+    assert!(response.clock >= 1);
+
+    // Since this is the first sync, no operations should be returned
+    assert_eq!(response.operations.len(), 0);
+}
+
+#[tokio::test]
+async fn test_sync_between_devices() {
+    // Setup
+    let db_pool = create_test_db().await;
+    let app = create_test_app(db_pool);
+
+    // Device 1 sends an operation
+    let operation1 = CrdtOperation::UpsertTab {
+        id: "tab-1".to_string(),
+        data: TabData {
+            window_id: "window-1".to_string(),
+            url: "https://example.com".to_string(),
+            title: "Example".to_string(),
+            active: true,
+            index: 0,
+            updated_at: 123_456_789,
+        },
+    };
+
+    let request1 = SyncRequest {
+        clock: 1,
+        device_id: "device-1".to_string(),
+        since_clock: None,
+        operations: vec![operation1],
+    };
+
+    let (status1, body1) = make_sync_request(app.clone(), "test-token", request1).await;
+    assert_eq!(status1, StatusCode::OK);
+    let _response1: SyncResponse = serde_json::from_str(&body1).unwrap();
+
+    // Device 2 syncs and should receive device 1's operation
+    let request2 = SyncRequest {
+        clock: 0,
+        device_id: "device-2".to_string(),
+        since_clock: None,
+        operations: vec![],
+    };
+
+    let (status2, body2) = make_sync_request(app.clone(), "test-token", request2).await;
+    assert_eq!(status2, StatusCode::OK);
+    let response2: SyncResponse = serde_json::from_str(&body2).unwrap();
+
+    // Device 2 should receive the operation from device 1
+    assert_eq!(response2.operations.len(), 1);
+
+    match &response2.operations[0] {
+        CrdtOperation::UpsertTab { id, data } => {
+            assert_eq!(id, "tab-1");
+            assert_eq!(data.url, "https://example.com");
+        }
+        _ => panic!("Expected UpsertTab operation"),
+    }
+}
+
+#[tokio::test]
+async fn test_sync_with_multiple_operation_types() {
+    let db_pool = create_test_db().await;
+    let app = create_test_app(db_pool);
+
+    // Create various operations - use different tabs to avoid ID conflicts
+    let operations = vec![
+        CrdtOperation::UpsertTab {
+            id: "tab-1".to_string(),
+            data: TabData {
+                window_id: "window-1".to_string(),
+                url: "https://example.com".to_string(),
+                title: "Example".to_string(),
+                active: true,
+                index: 0,
+                updated_at: 123_456_789,
+            },
+        },
+        CrdtOperation::UpsertTab {
+            id: "tab-2".to_string(),
+            data: TabData {
+                window_id: "window-1".to_string(),
+                url: "https://example2.com".to_string(),
+                title: "Example 2".to_string(),
+                active: false,
+                index: 1,
+                updated_at: 123_456_790,
+            },
+        },
+        CrdtOperation::TrackWindow {
+            id: "window-1".to_string(),
+            tracked: true,
+            updated_at: 123_456_791,
+        },
+        CrdtOperation::ChangeUrl {
+            id: "tab-1".to_string(),
+            url: "https://updated.com".to_string(),
+            title: Some("Updated".to_string()),
+            updated_at: 123_456_792,
+        },
+    ];
+
+    let request = SyncRequest {
+        clock: 1,
+        device_id: "device-1".to_string(),
+        since_clock: None,
+        operations,
+    };
+
+    let (status, body) = make_sync_request(app, "test-token", request).await;
+
+    // Debug print the response if not OK
+    if status != StatusCode::OK {
+        println!("Error response: {body}");
+    }
+
+    assert_eq!(status, StatusCode::OK);
+    let response: SyncResponse = serde_json::from_str(&body).unwrap();
+
+    // Server should accept all operations
+    assert!(response.clock >= 4); // At least 4 operations were processed
+}
+
+#[tokio::test]
+async fn test_sync_with_invalid_operation() {
+    let db_pool = create_test_db().await;
+    let app = create_test_app(db_pool);
+
+    // Create operation with invalid data (empty tab ID)
+    let operation = CrdtOperation::UpsertTab {
+        id: String::new(), // Invalid: empty ID
+        data: TabData {
+            window_id: "window-1".to_string(),
+            url: "https://example.com".to_string(),
+            title: "Example".to_string(),
+            active: true,
+            index: 0,
+            updated_at: 123_456_789,
+        },
+    };
+
+    let request = SyncRequest {
+        clock: 1,
+        device_id: "device-1".to_string(),
+        since_clock: None,
+        operations: vec![operation],
+    };
+
+    let (status, body) = make_sync_request(app, "test-token", request).await;
+
+    // Should return validation error
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(body.contains("validation") || body.contains("empty"));
+}
+
+#[tokio::test]
+async fn test_incremental_sync() {
+    let db_pool = create_test_db().await;
+    let app = create_test_app(db_pool);
+
+    // First sync from device 1
+    let operation1 = CrdtOperation::UpsertTab {
+        id: "tab-1".to_string(),
+        data: TabData {
+            window_id: "window-1".to_string(),
+            url: "https://example.com".to_string(),
+            title: "Example".to_string(),
+            active: true,
+            index: 0,
+            updated_at: 123_456_789,
+        },
+    };
+
+    let request1 = SyncRequest {
+        clock: 1,
+        device_id: "device-1".to_string(),
+        since_clock: None,
+        operations: vec![operation1],
+    };
+
+    let (status1, body1) = make_sync_request(app.clone(), "test-token", request1).await;
+    assert_eq!(status1, StatusCode::OK);
+    let response1: SyncResponse = serde_json::from_str(&body1).unwrap();
+    let first_sync_clock = response1.clock;
+
+    // Second sync from device 1 with another operation
+    let operation2 = CrdtOperation::UpsertTab {
+        id: "tab-2".to_string(),
+        data: TabData {
+            window_id: "window-1".to_string(),
+            url: "https://example2.com".to_string(),
+            title: "Example 2".to_string(),
+            active: false,
+            index: 1,
+            updated_at: 123_456_790,
+        },
+    };
+
+    let request2 = SyncRequest {
+        clock: first_sync_clock,
+        device_id: "device-1".to_string(),
+        since_clock: Some(first_sync_clock),
+        operations: vec![operation2],
+    };
+
+    let (status2, body2) = make_sync_request(app.clone(), "test-token", request2).await;
+    assert_eq!(status2, StatusCode::OK);
+    let _response2: SyncResponse = serde_json::from_str(&body2).unwrap();
+
+    // Device 2 syncs with since_clock from first sync
+    let request3 = SyncRequest {
+        clock: 0,
+        device_id: "device-2".to_string(),
+        since_clock: Some(first_sync_clock),
+        operations: vec![],
+    };
+
+    let (status3, body3) = make_sync_request(app.clone(), "test-token", request3).await;
+    assert_eq!(status3, StatusCode::OK);
+    let response3: SyncResponse = serde_json::from_str(&body3).unwrap();
+
+    // Device 2 should only receive the second operation
+    assert_eq!(response3.operations.len(), 1);
+    match &response3.operations[0] {
+        CrdtOperation::UpsertTab { id, data } => {
+            assert_eq!(id, "tab-2");
+            assert_eq!(data.url, "https://example2.com");
+        }
+        _ => panic!("Expected UpsertTab operation for tab-2"),
+    }
+}


### PR DESCRIPTION
## Summary

- ✅ Created 7 comprehensive integration tests for the sync endpoint
- 🔧 Fixed clock increment issue by adding `tick_clock()` method to CrdtManager
- 📚 Added test documentation in `server/tests/README.md`

## Test Coverage

The integration tests cover:

1. **Basic Operations**
   - Empty sync requests
   - Single tab creation

2. **Authentication**
   - Invalid token rejection

3. **Multi-Device Sync**
   - Operations sync between different devices
   - Incremental sync with clock tracking

4. **Complex Operations**
   - Multiple CRDT operation types in one request

5. **Error Handling**
   - Operation validation

## Implementation Details

- Tests use in-memory SQLite for isolation
- Fixed duplicate ID issue when multiple operations were in same request
- Server now properly increments Lamport clock for each operation
- Device-specific filtering prevents operation echo

## CI Updates

- Updated pre-commit hooks to run all Rust tests (not just lib tests)
- Updated GitHub Actions CI to run integration tests

All tests are passing ✅