### PR TITLE
fix: enable carryforward for codecov flags to fix unknown badge

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -36,12 +36,12 @@ flags:
   extension:
     paths:
       - extension/
-    carryforward: false
+    carryforward: true
     target: 75% # Extension coverage threshold
   server:
     paths:
       - server/
-    carryforward: false
+    carryforward: true
     target: 40% # Server coverage threshold
 
 comment:


### PR DESCRIPTION
## Summary
- Enable carryforward for both extension and server codecov flags
- This fixes the "unknown" status on the codecov badge in README

## Problem
The codecov badge was showing "unknown" because the project has two separate coverage flags (extension and server) with `carryforward: false`. This prevented codecov from calculating a combined coverage percentage for the main badge.

## Solution
Setting `carryforward: true` for both flags allows codecov to:
- Include both server and extension coverage in the overall project coverage
- Carry forward the last known coverage if a flag isn't uploaded in a particular build
- Display the combined coverage percentage on the badge (~79.7% currently)

## Test plan
- [x] Updated codecov.yml configuration
- [ ] After merge, verify the codecov badge shows actual coverage percentage instead of "unknown"
- [ ] Confirm both extension and server coverage are still tracked separately in codecov dashboard

🤖 Generated with [Claude Code](https://claude.ai/code)