### PR TITLE
fix: align message protocol between popup and background script

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -68,9 +68,10 @@ These bugs prevent Tanaka from fulfilling its primary purpose:
 **Fix**: Trigger immediate sync when queue exceeds threshold  
 **Status**: Completed - Queue threshold now triggers immediate sync when 50+ operations pending
 
-#### `fix/message-protocol` - Message Protocol Inconsistency
+#### `fix/message-protocol` - Message Protocol Inconsistency ✅
 **Impact**: Popup shows errors or blank window list  
-**Fix**: Align message handler response with popup expectations
+**Fix**: Align message handler response with popup expectations  
+**Status**: Completed in PR #72
 
 #### `fix/initial-sync` - Initial Sync Truncation
 **Impact**: New devices silently lose tabs beyond first 100  
@@ -201,7 +202,7 @@ Prepare for v1.0 release with performance optimization, monitoring, and Mozilla 
 - [x] Server restarts don't lose data - state restored from database
 - [x] Operations applied in correct order with atomic Lamport clock
 - [x] Sync happens within 1s during activity (queue threshold working)
-- [ ] Popup displays correct window list without errors
+- [x] Popup displays correct window list without errors
 - [ ] New devices receive complete state (>100 tabs supported)
 - [ ] Server runs indefinitely without memory leaks
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -22,8 +22,9 @@
 1. **Device Authentication Bug** - All devices are forced to use the same device_id, making multi-device sync impossible
 2. ~~**Server State Loss** - Server loses all data on restart (no persistence)~~ ✅ Fixed in PR #69
 3. **Memory Leaks** - Server eventually crashes due to rate limiter memory leak
-4. **Sync Delays** - Users may wait up to 10s for sync after rapid changes
-5. **Data Truncation** - New devices lose tabs beyond the first 100
+4. ~~**Sync Delays** - Users may wait up to 10s for sync after rapid changes~~ ✅ Fixed in PR #71
+5. ~~**Popup Message Protocol** - Popup shows errors or blank window list~~ ✅ Fixed in PR #72
+6. **Data Truncation** - New devices lose tabs beyond the first 100
 
 ### Security Issues
 - Overly permissive CORS configuration

--- a/extension/src/core.ts
+++ b/extension/src/core.ts
@@ -5,7 +5,10 @@ export type Message =
   | { type: 'CONFIG_UPDATED' }
   | { type: 'SETTINGS_UPDATED' };
 
-export type MessageResponse = { windowIds: number[] } | { success: boolean } | { error: string };
+export type MessageResponse =
+  | { windowIds: number[]; titles?: string[] }
+  | { success: boolean }
+  | { error: string };
 
 export function asMessage(value: unknown): Message | null {
   if (typeof value !== 'object' || value === null || !('type' in value)) {

--- a/extension/src/popup/components/WindowTracker.tsx
+++ b/extension/src/popup/components/WindowTracker.tsx
@@ -36,10 +36,10 @@ export function WindowTracker() {
           error?: string;
         };
 
-        if (response.windowIds && response.titles) {
+        if (response.windowIds) {
           // Initialize the tracked windows state
           const windowsMap = new Map();
-          response.windowIds?.forEach((id: number, index: number) => {
+          response.windowIds.forEach((id: number, index: number) => {
             windowsMap.set(id, {
               id,
               title: response.titles?.[index],

--- a/extension/src/sync/__tests__/message-handler.test.ts
+++ b/extension/src/sync/__tests__/message-handler.test.ts
@@ -156,6 +156,25 @@ describe('MessageHandler', () => {
       expect(mockWindowTracker.getTrackedWindows).toHaveBeenCalled();
       expect(response).toEqual({ windowIds: [] });
     });
+
+    it('returns response matching new MessageResponse type format', async () => {
+      const message = { type: 'GET_TRACKED_WINDOWS' };
+      (mockWindowTracker.getTrackedWindows as jest.Mock).mockReturnValue([123]);
+
+      const response = await messageHandler.handleMessage(message);
+
+      // Verify response matches { windowIds: number[]; titles?: string[] } format
+      expect(response).toHaveProperty('windowIds');
+      expect(Array.isArray(response.windowIds)).toBe(true);
+      expect(response.windowIds).toEqual([123]);
+
+      // Titles should be optional (undefined is fine)
+      expect(response.titles).toBeUndefined();
+
+      // Response should not have success or error properties for GET_TRACKED_WINDOWS
+      expect(response).not.toHaveProperty('success');
+      expect(response).not.toHaveProperty('error');
+    });
   });
 
   describe('edge cases', () => {


### PR DESCRIPTION
## Summary
- Fixes message protocol inconsistency causing popup errors/blank window lists
- Makes titles optional in MessageResponse type to match actual usage
- Updates popup logic to work with just windowIds array

## Problem
The popup expected both `windowIds` and `titles` arrays from GET_TRACKED_WINDOWS messages, but the background script only returned `windowIds`. This caused the condition `response.windowIds && response.titles` to fail, resulting in blank popup displays.

## Solution
- Updated MessageResponse type union: `{ windowIds: number[]; titles?: string[] }`
- Changed popup condition from `response.windowIds && response.titles` to `response.windowIds`
- Maintained backward compatibility with optional title support

## Test Plan
- [x] TypeScript compilation passes
- [x] All 327 tests pass
- [x] Pre-commit hooks pass
- [x] Popup displays window tracking status correctly

🤖 Generated with [Claude Code](https://claude.ai/code)