### PR TITLE
chore: disable Codecov bot comments on pull requests

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -42,12 +42,14 @@ flags:
       - server/
     carryforward: true
 
-comment:
-  layout: "reach,diff,flags,files,footer"
-  behavior: default
-  require_changes: false
-  require_base: false
-  require_head: true
+# comment:
+#   layout: "reach,diff,flags,files,footer"
+#   behavior: default
+#   require_changes: false
+#   require_base: false
+#   require_head: true
+
+comment: false
 
 ignore:
   - "**/*.test.ts"


### PR DESCRIPTION
## Summary

Disables automatic Codecov bot comments on pull requests while preserving all coverage reporting functionality.

## Changes

- Replaced detailed comment configuration with `comment: false`
- Keeps all coverage targets, status checks, and dashboard functionality
- Maintains extension (75%) and server (40%) coverage requirements
- Preserves existing flags and ignore patterns

## Benefits

- **Reduces PR noise**: No more automated Codecov comments cluttering discussions
- **Maintains functionality**: Coverage status checks, dashboard, and CI integration remain active
- **Keeps standards**: All coverage targets and thresholds are preserved
- **Simple config**: Clean, minimal configuration following Codecov best practices

## Technical Details

The change replaces this complex comment configuration:
```yaml
comment:
  layout: "reach,diff,flags,files,footer"
  behavior: default
  require_changes: false
  require_base: false
  require_head: true
```

With this simple setting:
```yaml
comment: false
```

According to [Codecov documentation](https://community.codecov.com/t/is-it-possible-to-use-the-codecov-github-app-without-receiving-comments-from-the-bot/4111), this disables PR comments while maintaining all other Codecov functionality.

## Testing

- [x] YAML validation passes (pre-commit hooks)
- [x] Configuration follows Codecov best practices
- [x] No breaking changes to existing coverage setup

This will take effect on new pull requests after merging.

🤖 Generated with [Claude Code](https://claude.ai/code)