### PR TITLE
fix: add comprehensive Content Security Policy to manifest.json

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -15,6 +15,8 @@ This roadmap consolidates extension and server development, focusing on pending 
 
 ## 🌿 Branch Strategy (Pending Work)
 
+**⚠️ IMPORTANT: Always create feature branches with the exact names listed below. NEVER push directly to main.**
+
 ```
 main
 ├── Phase 3: Critical Fixes (small atomic branches)
@@ -91,9 +93,10 @@ These bugs prevent Tanaka from fulfilling its primary purpose:
 **Fix**: Allow only browser extension origins and configured domains  
 **Status**: Completed in PR #77
 
-#### `fix/csp-manifest` - Content Security Policy
+#### `fix/csp-manifest` - Content Security Policy ✅
 **Impact**: Required for Mozilla addon store submission  
-**Fix**: Add CSP to manifest.json
+**Fix**: Add CSP to manifest.json  
+**Status**: Completed - Added comprehensive CSP with strict security policy
 
 #### `fix/input-validation` - Input Validation ✅
 **Impact**: Potential DOS attacks  
@@ -213,7 +216,7 @@ Prepare for v1.0 release with performance optimization, monitoring, and Mozilla 
 
 #### Security & Compliance ✓
 - [x] CORS properly configured - only extension origins allowed
-- [ ] Content Security Policy added to manifest.json
+- [x] Content Security Policy added to manifest.json
 - [x] Input validation prevents DOS attacks
 - [ ] Permissions checked before each sync operation
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -14,7 +14,7 @@
   ],
 
   "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'self'"
+    "extension_pages": "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src https: wss:; object-src 'none'"
   },
 
   "background": {

--- a/extension/src/__tests__/csp-validation.test.ts
+++ b/extension/src/__tests__/csp-validation.test.ts
@@ -1,0 +1,53 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('Content Security Policy', () => {
+  it('should have a secure CSP configured in manifest.json', () => {
+    const manifestPath = path.join(__dirname, '../../manifest.json');
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+
+    expect(manifest.content_security_policy).toBeDefined();
+    expect(manifest.content_security_policy.extension_pages).toBeDefined();
+
+    const csp = manifest.content_security_policy.extension_pages;
+
+    // Verify CSP includes required directives
+    expect(csp).toContain("default-src 'none'");
+    expect(csp).toContain("script-src 'self'");
+    expect(csp).toContain("style-src 'self'");
+    expect(csp).toContain("object-src 'none'");
+    expect(csp).toContain('connect-src https: wss:');
+
+    // Verify CSP doesn't include unsafe directives
+    expect(csp).not.toContain('unsafe-inline');
+    expect(csp).not.toContain('unsafe-eval');
+    expect(csp).not.toContain('*');
+  });
+
+  it('should not have inline styles in HTML files', () => {
+    const htmlFiles = [
+      path.join(__dirname, '../popup/popup.html'),
+      path.join(__dirname, '../settings/settings.html'),
+    ];
+
+    htmlFiles.forEach((file) => {
+      const content = fs.readFileSync(file, 'utf-8');
+      expect(content).not.toMatch(/style\s*=/i);
+      expect(content).not.toMatch(/<style>/i);
+    });
+  });
+
+  it('should not have inline scripts in HTML files', () => {
+    const htmlFiles = [
+      path.join(__dirname, '../popup/popup.html'),
+      path.join(__dirname, '../settings/settings.html'),
+    ];
+
+    htmlFiles.forEach((file) => {
+      const content = fs.readFileSync(file, 'utf-8');
+      expect(content).not.toMatch(/onclick\s*=/i);
+      expect(content).not.toMatch(/onload\s*=/i);
+      expect(content).not.toMatch(/<script>/i);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add strict Content Security Policy required for Mozilla addon store submission
- Implement security best practices for browser extensions
- Add comprehensive tests to validate CSP configuration

## Changes
- Updated `manifest.json` with comprehensive CSP directives:
  - `default-src 'none'` for maximum security
  - Allow scripts and styles only from extension itself (`'self'`)
  - Allow HTTPS and WSS connections for sync server
  - Block all plugins/objects with `object-src 'none'`
  - Allow images from self and data URLs
  - Allow fonts from self

- Added CSP validation tests to ensure:
  - CSP is properly configured in manifest.json
  - No inline styles or scripts exist in HTML files
  - No unsafe directives are present

- Updated ROADMAP.md:
  - Added branch strategy warning to always use feature branches
  - Marked CSP task as completed

## Test Plan
- [x] Extension builds successfully with new CSP
- [x] All existing tests pass
- [x] New CSP validation tests pass
- [x] Manually tested extension functionality remains intact

Part of Phase 3 security fixes.

🤖 Generated with [Claude Code](https://claude.ai/code)