### PR TITLE
chore: rename SQLite database from tabs.db to tanaka.db

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5,6 +5,7 @@
 **Prerequisites**: Basic understanding of CRDTs and browser extensions
 
 ## Navigation
+
 - [🏠 Home](../README.md)
 - [🚀 Getting Started](GETTING-STARTED.md)
 - [💻 Development](DEVELOPMENT.md)
@@ -19,11 +20,11 @@
 ```
 ┌──────────────┐  JSON Operations via HTTPS  ┌──────────────┐
 │  Extension   │ ─────────────────────────▶  │   Server     │
-│ (TypeScript) │ ◀───────────────────────── │  (Rust)      │
-└──────────────┘    Adaptive 1-10s sync     └─────┬────────┘
+│ (TypeScript) │ ◀─────────────────────────  │  (Rust)      │
+└──────────────┘    Adaptive 1-10s sync      └─────┬────────┘
                                                    │  SQLite WAL
                                                    ▼
-                                             operations.db
+                                                tanaka.db
 ```
 
 ## Browser-side Workflow
@@ -69,16 +70,19 @@ Tanaka uses a structured JSON-based CRDT protocol for conflict-free synchronizat
 ## Security Architecture
 
 ### Authentication
+
 - Shared bearer token in Authorization header
 - Token configured in both extension and server
 - No user accounts or sessions (personal use)
 
 ### Transport Security
+
 - HTTPS/TLS required for all communication
 - Certificate validation on client side
 - Optional self-signed certs for development
 
 ### Data Protection
+
 - No plaintext storage of sensitive data
 - SQLite database with restricted permissions
 - Extension storage API for client-side data
@@ -86,6 +90,7 @@ Tanaka uses a structured JSON-based CRDT protocol for conflict-free synchronizat
 ## Performance Considerations
 
 ### Targets (Phase 5 Goals)
+
 - Support 200+ tabs across devices
 - P95 sync latency ≤ 10ms
 - Smooth UI with no blocking operations
@@ -93,6 +98,7 @@ Tanaka uses a structured JSON-based CRDT protocol for conflict-free synchronizat
 > **Current Status**: Performance optimization is planned for [Phase 5](ROADMAP.md#-phase-5-production-ready) after critical fixes and UI redesign are complete.
 
 ### Optimizations
+
 - DashMap for in-memory caching
 - SQLite WAL mode for concurrent reads
 - Statement caching for prepared queries
@@ -103,13 +109,15 @@ Tanaka uses a structured JSON-based CRDT protocol for conflict-free synchronizat
 ## Storage Architecture
 
 ### Client Storage
+
 - `browser.storage.local` for tab state and sync metadata
 - Operation queue for pending CRDT operations
 - Device ID and Lamport clock persistence
 - Settings in storage.sync
 
 ### Server Storage
-- SQLite database (operations.db) with WAL mode
+
+- SQLite database (tanaka.db) with WAL mode
 - CRDT operations table with Lamport clock indexing
 - Materialized state table for current tab/window data
 - DashMap cache for hot operations
@@ -118,17 +126,20 @@ Tanaka uses a structured JSON-based CRDT protocol for conflict-free synchronizat
 ## Extension Architecture
 
 ### Background Service
+
 - Persistent background script
 - Manages all tab/window events
 - Handles sync operations
 - Message broker for UI components
 
 ### UI Components
+
 - Popup: Window tracking controls
 - Settings: Server configuration
 - Future: Tab search and management
 
 ### Message Passing
+
 - Background ↔ Popup communication
 - Background ↔ Settings communication
 - Structured message types with TypeScript
@@ -155,12 +166,14 @@ Main Thread                 Web Worker Thread
 ```
 
 **Key Benefits:**
+
 - Non-blocking UI during sync operations
 - Parallel processing of CRDT operations
 - Efficient handling of 200+ tabs
 - Reduced memory pressure on main thread
 
 **Components:**
+
 - `CrdtWorker`: Handles operation queuing and deduplication
 - `CrdtWorkerClient`: Main thread interface with timeout protection
 - `SyncManagerWithWorker`: Drop-in replacement for SyncManager
@@ -168,12 +181,14 @@ Main Thread                 Web Worker Thread
 ## Future Architecture Plans
 
 ### v1.0 Enhancements
+
 - Repository pattern for data access
 - Service layer with dependency injection
 - Enhanced CRDT protocol with compression
 - Observability with metrics and tracing
 
 ### v2.0 Vision
+
 - P2P sync option
 - Cross-browser support
 - Collaborative tab sharing

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -24,7 +24,7 @@
 └──────────────┘      5 s poll       └─────┬────────┘
                                            │  SQLite WAL
                                            ▼
-                                   operations.db
+                                        tanaka.db
 ```
 
 ### 1.1 Browser-side Workflow
@@ -262,7 +262,7 @@ sqlx migrate add -r add_user_preferences_table
 
 ```bash
 # Ensure DATABASE_URL is set (or create .env file)
-export DATABASE_URL=sqlite://tabs.db
+export DATABASE_URL=sqlite://tanaka.db
 
 # Create the database if it doesn't exist
 sqlx database create
@@ -511,7 +511,7 @@ Create `server/.env` for development:
 
 ```bash
 RUST_LOG=debug
-DATABASE_URL=sqlite://tabs.db
+DATABASE_URL=sqlite://tanaka.db
 BIND_ADDR=127.0.0.1:8000
 AUTH_TOKEN=dev-token
 ```
@@ -820,7 +820,7 @@ import { Card } from "../components";
 ### Server Debugging
 
 1. **Enable debug logging**: `RUST_LOG=debug cargo run`
-2. **Database inspection**: `sqlite3 tabs.db .tables`
+2. **Database inspection**: `sqlite3 tanaka.db .tables`
 3. **Monitor performance**: Check request logs and response times
 
 ### Common Issues

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -5,6 +5,7 @@
 **Prerequisites**: Firefox 126+ and basic command line knowledge
 
 ## Navigation
+
 - [🏠 Home](../README.md)
 - [🚀 Getting Started](GETTING-STARTED.md)
 - [💻 Development](DEVELOPMENT.md)
@@ -33,6 +34,7 @@ curl -LO https://github.com/goodbadwolf/tanaka/releases/latest/download/tanaka.x
 ### Step 2: Install the Server
 
 **Option A - Download Pre-built Binary (Recommended)**
+
 ```bash
 # Download server for your platform
 curl -LO https://github.com/goodbadwolf/tanaka/releases/latest/download/tanaka-server-$(uname -m)-$(uname -s | tr '[:upper:]' '[:lower:]')
@@ -41,6 +43,7 @@ sudo mv tanaka-server-* /usr/local/bin/tanaka-server
 ```
 
 **Option B - Build from Source**
+
 ```bash
 # Requires Rust installed (rustup.rs)
 git clone https://github.com/goodbadwolf/tanaka.git
@@ -51,11 +54,13 @@ sudo cp target/release/tanaka-server /usr/local/bin/
 ### Step 3: Configure & Run
 
 1. Create config directory:
+
    ```bash
    mkdir -p ~/.config/tanaka
    ```
 
 2. Create `~/.config/tanaka/tanaka.toml`:
+
    ```toml
    [server]
    bind_addr = "127.0.0.1:8443"  # For local use
@@ -92,11 +97,11 @@ sudo cp target/release/tanaka-server /usr/local/bin/
 
 ## System Requirements
 
-| Component | Requirement |
-|-----------|-------------|
-| Firefox | Version 126 or newer |
-| Server OS | Linux, macOS, or Windows |
-| SQLite | Version 3.40+ (usually pre-installed) |
+| Component       | Requirement                              |
+| --------------- | ---------------------------------------- |
+| Firefox         | Version 126 or newer                     |
+| Server OS       | Linux, macOS, or Windows                 |
+| SQLite          | Version 3.40+ (usually pre-installed)    |
 | TLS Certificate | Self-signed or Let's Encrypt (for HTTPS) |
 
 ---
@@ -150,6 +155,7 @@ shared_token = "dev-token"
 ### Linux (systemd)
 
 1. Create system user:
+
    ```bash
    sudo useradd -r -s /bin/false -d /var/lib/tanaka tanaka
    sudo mkdir -p /var/lib/tanaka
@@ -157,6 +163,7 @@ shared_token = "dev-token"
    ```
 
 2. Create `/etc/systemd/system/tanaka.service`:
+
    ```ini
    [Unit]
    Description=Tanaka Server
@@ -210,16 +217,18 @@ Load with: `launchctl load ~/Library/LaunchAgents/com.tanaka.server.plist`
 ## Backup & Restore
 
 ### Backup Database
+
 ```bash
 # Create backup while server is running
-sqlite3 /var/lib/tanaka/tabs.db ".backup '/backup/tabs-$(date +%Y%m%d).db'"
+sqlite3 /var/lib/tanaka/tanaka.db ".backup '/backup/tabs-$(date +%Y%m%d).db'"
 ```
 
 ### Restore Database
+
 ```bash
 # Stop server, replace database, restart
 sudo systemctl stop tanaka
-sudo cp /backup/tabs-20240315.db /var/lib/tanaka/tabs.db
+sudo cp /backup/tabs-20240315.db /var/lib/tanaka/tanaka.db
 sudo systemctl start tanaka
 ```
 
@@ -228,10 +237,12 @@ sudo systemctl start tanaka
 ## Uninstall
 
 ### Remove Extension
+
 1. Go to `about:addons` in Firefox
 2. Find Tanaka and click Remove
 
 ### Remove Server
+
 ```bash
 # Stop service
 sudo systemctl disable --now tanaka  # Linux

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -5,6 +5,7 @@
 **Prerequisites**: Basic command line knowledge
 
 ## Navigation
+
 - [🏠 Home](../README.md)
 - [🚀 Getting Started](GETTING-STARTED.md)
 - [💻 Development](DEVELOPMENT.md)
@@ -19,6 +20,7 @@
 > **SUCCESS**: All Phase 3 critical fixes have been implemented! Multi-device synchronization is now fully functional.
 
 ### Fixed Issues
+
 1. **Device Authentication** ✅ Fixed in PR #74
 2. **Server State Persistence** ✅ Fixed in PR #69
 3. **Memory Leaks** ✅ Fixed in PR #76
@@ -55,6 +57,7 @@
 ### Extension Not Loading
 
 **Symptoms:**
+
 - Extension doesn't appear in Firefox after installation
 - Icon missing from toolbar
 - "Corrupt add-on" error
@@ -62,18 +65,21 @@
 **Solutions:**
 
 1. **Verify Firefox version**:
+
    ```bash
    # Check version (needs 126+)
    firefox --version
    ```
 
 2. **Check manifest syntax**:
+
    ```bash
    cd extension
    npx web-ext lint
    ```
 
 3. **Reinstall extension**:
+
    - Remove from `about:addons`
    - Download fresh copy
    - Install again
@@ -85,6 +91,7 @@
 ### Server Connection Failures
 
 **Symptoms:**
+
 - "Failed to connect to server" error
 - Red connection indicator
 - Sync not working
@@ -92,11 +99,13 @@
 **Solutions:**
 
 1. **Certificate issues (HTTPS)**:
+
    - Navigate to server URL in browser
    - Accept self-signed certificate
    - Try extension again
 
 2. **Firewall blocking**:
+
    ```bash
    # Check if port is open
    telnet localhost 8443  # or your server port
@@ -106,6 +115,7 @@
    ```
 
 3. **Token mismatch**:
+
    ```bash
    # Check server token
    grep shared_token ~/.config/tanaka/tanaka.toml
@@ -120,6 +130,7 @@
 ### Sync Not Working
 
 **Symptoms:**
+
 - Tabs not appearing on other devices
 - Changes not propagating
 - Sync indicator stuck
@@ -127,10 +138,12 @@
 **Diagnostic Steps:**
 
 1. **Check extension console**:
+
    - `about:debugging` → This Firefox → Tanaka → Inspect
    - Look for sync errors
 
 2. **Verify server logs**:
+
    ```bash
    # Follow server logs
    tail -f ~/.local/share/tanaka/tanaka.log
@@ -139,6 +152,7 @@
    ```
 
 3. **Test server directly**:
+
    ```bash
    # Test sync endpoint
    curl -H "Authorization: Bearer YOUR_TOKEN" https://localhost:8443/sync
@@ -152,6 +166,7 @@
 ### High Memory Usage
 
 **Symptoms:**
+
 - Firefox using excessive RAM
 - Extension becomes sluggish
 - "Out of memory" errors
@@ -159,16 +174,19 @@
 **Solutions:**
 
 1. **Reduce tracked windows**:
+
    - Only track essential windows
    - Untrack before closing Firefox
 
 2. **Clear old data**:
+
    ```javascript
    // In extension console
    await browser.storage.local.clear();
    ```
 
 3. **Limit sync history**:
+
    - Server retains all history by default
    - Consider periodic database cleanup
 
@@ -209,10 +227,11 @@ RUST_BACKTRACE=1 cargo build -vv
 **Slow Extension Startup:**
 
 1. **Check stored data size**:
+
    ```javascript
    // In extension console
    const data = await browser.storage.local.get();
-   console.log('Storage size:', JSON.stringify(data).length);
+   console.log("Storage size:", JSON.stringify(data).length);
    ```
 
 2. **Disable during development**:
@@ -222,6 +241,7 @@ RUST_BACKTRACE=1 cargo build -vv
 **High CPU Usage:**
 
 1. **Check for runaway loops**:
+
    - Profile with Firefox Developer Tools
    - Look for hot functions
 
@@ -234,6 +254,7 @@ RUST_BACKTRACE=1 cargo build -vv
 ### Web Worker Issues
 
 **Symptoms:**
+
 - Extension freezes during sync
 - Worker initialization fails
 - "Worker is not defined" errors
@@ -241,17 +262,20 @@ RUST_BACKTRACE=1 cargo build -vv
 **Solutions:**
 
 1. **Check worker is loaded**:
+
    ```javascript
    // In extension console
    const workers = await browser.runtime.getBackgroundPage();
-   console.log('Worker available:', typeof Worker !== 'undefined');
+   console.log("Worker available:", typeof Worker !== "undefined");
    ```
 
 2. **Verify worker file exists**:
+
    - Check `dist/workers/crdt-worker.js` is present
    - Rebuild if missing: `pnpm run build:dev`
 
 3. **Debug worker errors**:
+
    ```javascript
    // In background script console
    // Look for worker initialization errors
@@ -304,6 +328,7 @@ pnpm run start -- --firefox="/Applications/Firefox.app/Contents/MacOS/firefox"
 ### Extension Debugging
 
 1. **Enable verbose logging**:
+
    ```typescript
    // Add to background.ts
    const DEBUG = true;
@@ -311,17 +336,19 @@ pnpm run start -- --firefox="/Applications/Firefox.app/Contents/MacOS/firefox"
    ```
 
 2. **Inspect storage**:
+
    ```javascript
    // View all stored data
    await browser.storage.local.get();
 
    // Watch for changes
    browser.storage.onChanged.addListener((changes, area) => {
-     console.log('Storage changed:', changes);
+     console.log("Storage changed:", changes);
    });
    ```
 
 3. **Monitor network requests**:
+
    - Open DevTools Network tab
    - Filter by "sync" or your server URL
    - Check request/response details
@@ -330,7 +357,7 @@ pnpm run start -- --firefox="/Applications/Firefox.app/Contents/MacOS/firefox"
    ```typescript
    // Log all messages
    browser.runtime.onMessage.addListener((msg, sender) => {
-     console.log('Message:', msg, 'From:', sender);
+     console.log("Message:", msg, "From:", sender);
      return true;
    });
    ```
@@ -338,13 +365,15 @@ pnpm run start -- --firefox="/Applications/Firefox.app/Contents/MacOS/firefox"
 ### Server Debugging
 
 1. **Enable debug logging**:
+
    ```bash
    RUST_LOG=debug tanaka-server
    ```
 
 2. **Inspect database**:
+
    ```bash
-   sqlite3 ~/.local/share/tanaka/tabs.db
+   sqlite3 ~/.local/share/tanaka/tanaka.db
    .tables
    SELECT * FROM tabs LIMIT 10;
    ```
@@ -359,15 +388,15 @@ pnpm run start -- --firefox="/Applications/Firefox.app/Contents/MacOS/firefox"
 
 ```typescript
 // In extension console
-import * as Y from 'yjs';
+import * as Y from "yjs";
 
 // Get current state
 const doc = syncManager.getDocument();
-console.log('Doc state:', doc.toJSON());
+console.log("Doc state:", doc.toJSON());
 
 // Check for pending updates
 const pending = Y.encodeStateAsUpdate(doc);
-console.log('Pending size:', pending.byteLength);
+console.log("Pending size:", pending.byteLength);
 ```
 
 ---
@@ -377,6 +406,7 @@ console.log('Pending size:', pending.byteLength);
 ### Certificate Problems
 
 1. **Generate new self-signed cert**:
+
    ```bash
    openssl req -x509 -newkey rsa:4096 \
      -keyout key.pem -out cert.pem \
@@ -385,6 +415,7 @@ console.log('Pending size:', pending.byteLength);
    ```
 
 2. **Check certificate details**:
+
    ```bash
    openssl x509 -in cert.pem -text -noout
    ```
@@ -397,16 +428,17 @@ console.log('Pending size:', pending.byteLength);
 ### Permission Issues
 
 1. **Check extension permissions**:
+
    ```javascript
    // List current permissions
    const perms = await browser.permissions.getAll();
-   console.log('Permissions:', perms);
+   console.log("Permissions:", perms);
    ```
 
 2. **Request missing permissions**:
    ```javascript
    await browser.permissions.request({
-     permissions: ['tabs']
+     permissions: ["tabs"],
    });
    ```
 
@@ -427,12 +459,14 @@ When reporting issues, include:
 
 ```markdown
 **Environment:**
+
 - OS: [e.g., macOS 13.5]
 - Firefox: [e.g., 126.0]
 - Tanaka Extension: [version from about:addons]
 - Tanaka Server: [run `tanaka-server --version`]
 
 **Steps to Reproduce:**
+
 1. [First step]
 2. [Second step]
 3. [What happens vs. what you expected]
@@ -455,15 +489,15 @@ When reporting issues, include:
 
 ```javascript
 // Profile sync operation
-console.time('sync');
+console.time("sync");
 await syncManager.sync();
-console.timeEnd('sync');
+console.timeEnd("sync");
 
 // Memory profiling
 if (performance.memory) {
-  console.log('Memory:', {
-    used: Math.round(performance.memory.usedJSHeapSize / 1048576) + 'MB',
-    total: Math.round(performance.memory.totalJSHeapSize / 1048576) + 'MB'
+  console.log("Memory:", {
+    used: Math.round(performance.memory.usedJSHeapSize / 1048576) + "MB",
+    total: Math.round(performance.memory.totalJSHeapSize / 1048576) + "MB",
   });
 }
 ```

--- a/extension/src/components/ErrorBoundary.test.tsx
+++ b/extension/src/components/ErrorBoundary.test.tsx
@@ -103,7 +103,7 @@ describe('ErrorBoundary', () => {
   it('should show error details when expanded', () => {
     const testError = new ExtensionError('DATABASE_ERROR', 'DB error', {
       source: 'test',
-      context: { database: 'tabs.db' },
+      context: { database: 'tanaka.db' },
     });
 
     render(
@@ -117,7 +117,7 @@ describe('ErrorBoundary', () => {
 
     expect(screen.getByText('Error Code:')).toBeInTheDocument();
     expect(screen.getByText('DATABASE_ERROR')).toBeInTheDocument();
-    expect(screen.getByText(/"database": "tabs.db"/)).toBeInTheDocument();
+    expect(screen.getByText(/"database": "tanaka.db"/)).toBeInTheDocument();
   });
 
   it('should handle retry functionality', () => {

--- a/server/.env.example
+++ b/server/.env.example
@@ -6,7 +6,7 @@ TANAKA_BIND_ADDR=127.0.0.1:8443
 TANAKA_LOG_LEVEL=info
 
 # Database configuration
-TANAKA_DATABASE_URL=sqlite://tabs.db
+TANAKA_DATABASE_URL=sqlite://tanaka.db
 
 # Authentication
 TANAKA_AUTH_TOKEN=your-secret-token-here

--- a/server/config/example.toml
+++ b/server/config/example.toml
@@ -11,7 +11,7 @@ request_timeout_secs = 30
 
 [database]
 # Database URL (SQLite example)
-url = "sqlite://tabs.db"
+url = "sqlite://tanaka.db"
 # Maximum database connections
 max_connections = 5
 # Connection timeout in seconds

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -146,7 +146,7 @@ fn default_max_concurrent_connections() -> usize {
 }
 
 fn default_database_url() -> String {
-    "sqlite://tabs.db".to_string()
+    "sqlite://tanaka.db".to_string()
 }
 
 fn default_pool_size() -> u32 {
@@ -404,7 +404,7 @@ mod tests {
     fn test_default_config() {
         let config = Config::default();
         assert_eq!(config.server.bind_addr, "127.0.0.1:8443");
-        assert_eq!(config.database.url, "sqlite://tabs.db");
+        assert_eq!(config.database.url, "sqlite://tanaka.db");
         assert_eq!(config.sync.poll_secs, 5);
     }
 


### PR DESCRIPTION
## Summary

This PR renames the default SQLite database filename from `tabs.db` to `tanaka.db` to better reflect the project name and maintain consistency across the codebase.

## Changes

- **Configuration**: Updated default database URL in `server/src/config.rs`
- **Environment**: Updated example environment file (`server/.env.example`)
- **Examples**: Updated example TOML configuration (`server/config/example.toml`)
- **Documentation**: Updated all references in documentation files:
  - `docs/ARCHITECTURE.md`
  - `docs/DEVELOPMENT.md`
  - `docs/GETTING-STARTED.md`
  - `docs/TROUBLESHOOTING.md`
- **Tests**: Fixed test assertion in ErrorBoundary component test

## Impact

This is a breaking change for existing installations. Users will need to either:
1. Rename their existing `tabs.db` file to `tanaka.db`, or
2. Update their configuration to explicitly specify `tabs.db` if they want to keep the old filename

## Testing

- [x] All tests pass
- [x] Pre-commit hooks pass
- [x] Documentation is consistent