### PR TITLE
docs: add instruction to commit after each task item

### DIFF
--- a/prototype/v3/TODOS-V3.md
+++ b/prototype/v3/TODOS-V3.md
@@ -14,10 +14,17 @@
 
 ```bash
 git checkout -b feat/your-task-name
-# Complete ALL checkboxes [ ] → [x]
 
-git add -p                    # Review & stage changes
-git commit -m "feat: ..."     # Feature commits
+# Work on each item and commit after EACH one
+# Example: After completing item 1
+git add -p
+git commit -m "feat: add scrollbar to index.html"
+
+# After completing item 2
+git add -p
+git commit -m "feat: delete tab-search page"
+
+# Continue this pattern for ALL items
 
 # Update BOTH TODO files before PR
 git add -p docs/TODOS.md prototype/v3/TODOS-V3.md
@@ -25,6 +32,8 @@ git commit -m "docs: mark task complete"
 
 git push origin feat/your-task-name
 ```
+
+**IMPORTANT**: ALWAYS COMMIT after completing EACH numbered item in a task. This creates a clear history and allows for easier rollback if needed.
 
 **PR Requirements:**
 


### PR DESCRIPTION
## Summary

This PR updates the v3 prototype TODO documentation to emphasize committing after completing each numbered task item.

## Changes

- Added clear workflow example showing item-by-item commits
- Emphasized the importance with "IMPORTANT" label
- Explained benefits: clear history and easier rollback

## Example

The updated workflow now shows:
```bash
# After completing item 1
git add -p
git commit -m "feat: add scrollbar to index.html"

# After completing item 2
git add -p
git commit -m "feat: delete tab-search page"
```

This ensures each piece of work is captured in its own commit, making the development history more granular and easier to review.