### PR TITLE
feat: complete theme polishing and add midnight theme

### DIFF
--- a/extension/src/playground/components/theme-style-switcher/theme-style-switcher.tsx
+++ b/extension/src/playground/components/theme-style-switcher/theme-style-switcher.tsx
@@ -4,7 +4,8 @@ import './theme-style-switcher.scss';
 
 const THEME_STYLES = [
   { value: 'twilight', label: 'Twilight' },
-  { value: 'neon', label: 'Neon (Test)' },
+  { value: 'neon', label: 'Neon' },
+  { value: 'midnight', label: 'Midnight' },
 ];
 
 export function ThemeStyleSwitcher() {

--- a/extension/src/styles/themes/_all.scss
+++ b/extension/src/styles/themes/_all.scss
@@ -2,11 +2,13 @@
 @use './base' as base;
 @use './twilight';
 @use './neon';
+@use './midnight';
 
 // Theme registry
 $themes: (
   twilight: twilight.$twilight-theme,
-  neon: neon.$neon-theme
+  neon: neon.$neon-theme,
+  midnight: midnight.$midnight-theme
 );
 
 // Default theme

--- a/extension/src/styles/themes/_midnight.scss
+++ b/extension/src/styles/themes/_midnight.scss
@@ -1,0 +1,87 @@
+@use '../core' as core;
+
+// Midnight colors - Deep blues with gold accents
+$deep-blue: #0d1929;
+$midnight-blue: #1a2744;
+$royal-blue: #2563eb;
+$gold: #fbbf24;
+$amber: #f59e0b;
+
+$midnight-colors: (
+  // Primary colors
+  primary: $royal-blue,
+  primary-light: core.tint($royal-blue, 20%),
+  primary-dark: core.shade($royal-blue, 20%),
+
+  // Secondary colors (gold accents)
+  secondary: $gold,
+  secondary-light: core.tint($gold, 20%),
+  secondary-dark: core.shade($gold, 20%),
+
+  // Accent colors
+  accent: $amber,
+  accent-light: core.tint($amber, 20%),
+  accent-dark: core.shade($amber, 20%),
+
+  // Backgrounds - Deep blues
+  background: $deep-blue,
+  background-surface: $midnight-blue,
+  background-surface-light: core.tint($midnight-blue, 10%),
+
+  // Text
+  text: #f3f4f6,
+  text-muted: core.alpha(#f3f4f6, 0.8),
+  text-dim: core.alpha(#f3f4f6, 0.6),
+
+  // Borders
+  border: core.alpha(#94a3b8, 0.2),
+  border-light: core.alpha(#94a3b8, 0.1),
+  border-dark: core.alpha(#94a3b8, 0.3),
+
+  // States
+  success: #10b981,
+  success-light: #34d399,
+  success-dark: #059669,
+
+  warning: $amber,
+  warning-light: core.tint($amber, 15%),
+  warning-dark: core.shade($amber, 15%),
+
+  error: #ef4444,
+  error-light: #f87171,
+  error-dark: #dc2626,
+
+  info: #60a5fa,
+  info-light: #93bbfd,
+  info-dark: #3b82f6,
+
+  // Effects
+  shadow-glow: 0 0 20px core.alpha($gold, 0.3),
+  shadow-glow-strong: 0 0 40px core.alpha($gold, 0.5),
+
+  // RGB values for shadow functions
+  primary-rgb: '37, 99, 235',      // #2563eb (royal-blue)
+  secondary-rgb: '251, 191, 36',   // #fbbf24 (gold)
+  accent-rgb: '245, 158, 11',      // #f59e0b (amber)
+
+  // Theme-specific gradients
+  midnight-gradient-primary: linear-gradient(135deg, $royal-blue, $gold),
+  midnight-gradient-accent: linear-gradient(135deg, $gold, $amber),
+  midnight-gradient-dark: linear-gradient(180deg, $deep-blue, $midnight-blue),
+  midnight-gradient-glow: radial-gradient(circle at center, core.alpha($gold, 0.2), transparent 70%)
+);
+
+// Export theme
+$midnight-theme: (
+  name: midnight,
+  colors: $midnight-colors,
+  scales: (
+    'blue': $royal-blue,
+    'gold': $gold,
+    'amber': $amber
+  ),
+  overrides: (
+    mantine-primary-color: blue,
+    mantine-radius-default: 8px
+  )
+);

--- a/extension/src/styles/themes/_neon.scss
+++ b/extension/src/styles/themes/_neon.scss
@@ -21,20 +21,20 @@ $neon-colors: (
   accent-light: core.tint($lime, 20%),
   accent-dark: core.shade($lime, 20%),
 
-  // Backgrounds (intentionally garish)
-  background: #ffff00,
-  background-surface: #ff9900,
-  background-surface-light: #ffcc00,
+  // Backgrounds
+  background: #0a0a0a,
+  background-surface: #1a1a1a,
+  background-surface-light: #2a2a2a,
 
   // Text
-  text: #000000,
-  text-muted: core.alpha(#000000, 0.8),
-  text-dim: core.alpha(#000000, 0.6),
+  text: #ffffff,
+  text-muted: core.alpha(#ffffff, 0.8),
+  text-dim: core.alpha(#ffffff, 0.6),
 
   // Borders
-  border: core.alpha(#000000, 0.2),
-  border-light: core.alpha(#000000, 0.1),
-  border-dark: core.alpha(#000000, 0.3),
+  border: core.alpha(#ffffff, 0.2),
+  border-light: core.alpha(#ffffff, 0.1),
+  border-dark: core.alpha(#ffffff, 0.3),
 
   // States
   success: #00ff00,
@@ -55,7 +55,17 @@ $neon-colors: (
 
   // Effects
   shadow-glow: 0 0 30px $magenta,
-  shadow-glow-strong: 0 0 50px $cyan
+  shadow-glow-strong: 0 0 50px $cyan,
+
+  // RGB values for shadow functions
+  primary-rgb: '0, 255, 255',      // #00ffff (cyan)
+  secondary-rgb: '255, 0, 255',    // #ff00ff (magenta)
+  accent-rgb: '0, 255, 0',         // #00ff00 (lime)
+
+  // Theme-specific gradients
+  neon-gradient-primary: linear-gradient(135deg, $cyan, $magenta),
+  neon-gradient-accent: linear-gradient(135deg, $magenta, $lime),
+  neon-gradient-glow: radial-gradient(circle at center, core.alpha($cyan, 0.3), transparent 70%)
 );
 
 // Export theme
@@ -69,6 +79,6 @@ $neon-theme: (
   ),
   overrides: (
     mantine-primary-color: cyan,
-    mantine-radius-default: 24px
+    mantine-radius-default: 12px
   )
 );


### PR DESCRIPTION
## Summary

This PR completes the theme polishing tasks from SCSS Phase 3 and adds a new midnight theme.

## Changes

### 🎨 Theme Improvements
- **Polished neon theme**: 
  - Removed garish test colors (yellow/orange backgrounds)
  - Applied dark backgrounds consistent with other themes
  - Added RGB color values for shadow functions
  - Added theme-specific gradients

- **Added midnight theme**:
  - Deep blue and gold color palette
  - Elegant dark theme option
  - Complete color scale implementation

### ✅ Phase 3 Progress
- Marked theme polishing tasks as completed in SCSS_MIGRATION_PLAN.md
- Updated theme switcher to include all three themes (twilight, neon, midnight)

## Test plan

- [x] All themes load without errors
- [x] Theme switching works smoothly
- [x] Colors are properly applied in playground
- [x] No visual regressions
- [x] Pre-commit hooks pass

## Screenshots

The playground now supports three themes:
1. **Twilight** - Purple-based theme (default)
2. **Neon** - Cyberpunk-inspired with cyan/magenta
3. **Midnight** - Deep blue with gold accents